### PR TITLE
Added the Local JSON feature which saves post type settings to files …

### DIFF
--- a/acpt.php
+++ b/acpt.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Advanced Custom Post Types
 Description: Customise WordPress with custom post types
-Version: 0.2.0
+Version: 0.3.0
 Author: iambriansreed
 Author URI: http://iambrian.com/
 */

--- a/class-load.php
+++ b/class-load.php
@@ -15,17 +15,18 @@ class Load extends Load_Base {
 	}
 
 	function init() {
+		
+		$settings = new Settings();
 
-		$post_types = new Post_Types();
+		$post_types = new Post_Types( $settings );
 
 		$post_types->register();
 
 		if ( is_admin() ) {
 
-			$settings     = new Settings();
-			$dashicons    = new Dashicons();
-			$fields       = new Fields( $settings, $dashicons );
-			$post_type    = new Post_Type( $fields, $dashicons );
+			$dashicons = new Dashicons();
+			$fields    = new Fields( $settings, $dashicons );
+			$post_type = new Post_Type( $settings, $fields, $dashicons );
 
 			new Admin\Load( $settings, $post_types, $fields, $post_type );
 		}

--- a/class-post-types.php
+++ b/class-post-types.php
@@ -4,6 +4,13 @@ namespace Advanced_Custom_Post_Types;
 
 class Post_Types {
 
+	private $json_path = '';
+
+	function __construct( Settings $settings ) {
+
+		$this->json_path = $settings->get( 'save_json' );
+	}
+
 	private function get_saved_data() {
 		return get_posts( array( 'post_type' => ACPT_POST_TYPE ) );
 	}
@@ -24,12 +31,35 @@ class Post_Types {
 		$post_types = array();
 
 		foreach ( $posts as $post ) {
-			$post_types[] = json_decode( $post->post_content, true );
+
+			$post_data = json_decode( $post->post_content, true );
+
+			$post_types[ $post_data['post_type'] ] = $post_data;
 		}
 
-		$post_types = apply_filters( 'acpt/post_types', $post_types );
+		if ( $this->json_path ) {
+
+			$files = scandir( $this->json_path );
+
+			foreach ( $files as $file ) {
+
+				if ( substr( $file, - 5 ) === '.json' ) {
+
+					$post_type_json = file_get_contents( "$this->json_path/$file" );
+
+					$post_data = json_decode( $post_type_json, true );
+
+					$post_types[ $post_data['post_type'] ] = $post_data;
+				}
+			}
+		}
 
 		return $post_types;
+
+	}
+
+	public function valid_post_type( $post_type ) {
+		return is_string( $post_type ) && strlen( $post_type ) > 0 && strlen( $post_type ) < 21;
 	}
 
 	public function register() {
@@ -42,7 +72,7 @@ class Post_Types {
 
 		foreach ( $post_types as $post_type ) {
 
-			if ( ! isset( $post_type['post_type'] ) || ! isset( $post_type['args'] ) ) {
+			if ( ! isset( $post_type['post_type'] ) || ! $this->valid_post_type( $post_type['post_type'] ) || ! isset( $post_type['args'] ) ) {
 				continue;
 			}
 

--- a/class-settings.php
+++ b/class-settings.php
@@ -9,8 +9,9 @@ class Settings {
 	function __construct() {
 
 		$this->defaults = array(
-			'show_admin'   => true,
-			'capability'   => 'manage_options'
+			'show_admin' => true,
+			'capability' => 'manage_options',
+			'save_json'  => null
 		);
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,11 +16,9 @@ Advanced Custom Post Types is the perfect solution for any WordPress website whi
 
 **acpt/settings/show_admin** - Determines whether or not the admin menu is shown.
 
-**acpt/settings/admin_fields** - Determines which field groups may appear in the post type editor.
-
 **acpt/settings/capability** - Determines capability is needed to manage custom post types.
 
-**acpt/post_types** - Alter the post types created
+**acpt/settings/save_json** - The path to save post types locally. 
 
 == Actions ==
 
@@ -59,3 +57,8 @@ Coming soon!
 
 = 0.2.0 =
 * Massive refactoring and cleanup, added export
+
+= 0.3.0 =
+* Added the Local JSON feature which saves post type settings to files within your theme. The idea is similar to caching and both dramatically speeds up ACPT and allows for version control over your post type settings. Removed unused filters and added the save_json filter to determine where post type setting files are saved.
+
+ 


### PR DESCRIPTION
…within your theme. The idea is similar to caching and both dramatically speeds up ACPT and allows for version control over your post type settings. Removed unused filters and added the save_json filter to determine where post type setting files are saved.
